### PR TITLE
feat: implementacion obtener_estado_tablero_visible

### DIFF
--- a/buscaminas.py
+++ b/buscaminas.py
@@ -100,8 +100,14 @@ def crear_juego(filas: int, columnas: int, minas: int) -> EstadoJuego:
     return res
 
 
+def copiar_matriz(tablero: list[list[str]]) -> list[list[str]]:
+    copia_del_tablero: list[list[str]] = []
+    for filas in tablero:
+        copia_del_tablero.append(filas.copy())
+    return copia_del_tablero
+
 def obtener_estado_tablero_visible(estado: EstadoJuego) -> list[list[str]]:
-    return [[]]
+    return copiar_matriz(estado["tablero_visible"])
 
 
 def marcar_celda(estado: EstadoJuego, fila: int, columna: int) -> None:

--- a/tests_materia.py
+++ b/tests_materia.py
@@ -112,6 +112,20 @@ class crear_juegoTest(unittest.TestCase):
         # Testeamos que haya una mina en el tablero
         self.assertEqual(cant_minas_en_tablero(estado['tablero']), minas)
 
+class obtener_estado_tablero_visibleTest(unittest.TestCase):
+    def test_ejemplo(self):
+        mock_tablero_visible: list[list[str]] = [[" ", " "],[" ", " "]]
+        estado: EstadoJuego = {
+            "filas": 2,
+            "columnas": 2,
+            "minas": 1,
+            "tablero_visible": mock_tablero_visible,
+            "juego_terminado": False,
+            "tablero": [[1, 1],[-1, 1]]
+        }
+        tablero_visible = obtener_estado_tablero_visible(estado)
+        self.assertEqual(tablero_visible, mock_tablero_visible)
+
 
 """ class marcar_celdaTest(unittest.TestCase):
     def test_ejemplo(self):


### PR DESCRIPTION
# feat: implementacion obtener_estado_tablero_visible

## Descripción
Implementé la función obtener_estado_tablero_visible

## Cambios realizados
Como se necesitaba una copia cree la funcion aux copiar_matriz ademas de implementar obtener_estado_tablero_visible.

## Checklist
- [x] He seguido el formato de nombre de branch correcto (`{feat|fix|chore}/{nombre_funcionalidad}`)
- [x] He seguido el formato de título de PR correcto (`{feat|fix|chore}: descripción`)
- [x] He testeado los cambios localmente
- [x] He actualizado la documentación si es necesario

## Screenshots (si aplica)
![Captura desde 2025-06-04 21-53-17](https://github.com/user-attachments/assets/9522bf41-5ad0-40fc-9e35-2e092250f416)

